### PR TITLE
feat: create solid-faint-black and solid-bright-white tokens

### DIFF
--- a/lib/borders/index.d.ts
+++ b/lib/borders/index.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Jul 2023 21:18:11 GMT
+ * Generated on Mon, 31 Jul 2023 14:44:47 GMT
  */
 
 export default borders;

--- a/lib/borders/index.js
+++ b/lib/borders/index.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Jul 2023 21:18:11 GMT
+ * Generated on Mon, 31 Jul 2023 14:44:47 GMT
  */
 
 module.exports = {

--- a/lib/colors/index.d.ts
+++ b/lib/colors/index.d.ts
@@ -1,8 +1,9 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Jul 2023 21:18:11 GMT
+ * Generated on Mon, 31 Jul 2023 14:44:47 GMT
  */
 
+export const solidFaintBlack: string;
 export const solidFaintDarkest: string;
 export const solidFaintDarker: string;
 export const solidFaintDark: string;
@@ -13,6 +14,7 @@ export const solidBrightMedium: string;
 export const solidBrightLight: string;
 export const solidBrightLighter: string;
 export const solidBrightLightest: string;
+export const solidBrightWhite: string;
 export const solidPrimaryDarkest: string;
 export const solidPrimaryDark: string;
 export const solidPrimaryMedium: string;

--- a/lib/colors/index.js
+++ b/lib/colors/index.js
@@ -1,8 +1,9 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Jul 2023 21:18:11 GMT
+ * Generated on Mon, 31 Jul 2023 14:44:47 GMT
  */
 
+export const solidFaintBlack = '#000000';
 export const solidFaintDarkest = '#0e0f12';
 export const solidFaintDarker = '#1c1d21';
 export const solidFaintDark = '#333840';
@@ -12,7 +13,8 @@ export const solidBrightDark = '#9ea3ab';
 export const solidBrightMedium = '#c9ced6';
 export const solidBrightLight = '#e6eaf0';
 export const solidBrightLighter = '#f5f6f7';
-export const solidBrightLightest = '#ffffff';
+export const solidBrightLightest = '#fbfbfb';
+export const solidBrightWhite = '#ffffff';
 export const solidPrimaryDarkest = '#002769';
 export const solidPrimaryDark = '#1d52a8';
 export const solidPrimaryMedium = '#3172de';

--- a/lib/radius/index.d.ts
+++ b/lib/radius/index.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Jul 2023 21:18:11 GMT
+ * Generated on Mon, 31 Jul 2023 14:44:47 GMT
  */
 
 export default radius;

--- a/lib/radius/index.js
+++ b/lib/radius/index.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Jul 2023 21:18:11 GMT
+ * Generated on Mon, 31 Jul 2023 14:44:47 GMT
  */
 
 module.exports = {

--- a/lib/shadows/index.d.ts
+++ b/lib/shadows/index.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Jul 2023 21:18:11 GMT
+ * Generated on Mon, 31 Jul 2023 14:44:47 GMT
  */
 
 export default shadows;

--- a/lib/shadows/index.js
+++ b/lib/shadows/index.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Jul 2023 21:18:11 GMT
+ * Generated on Mon, 31 Jul 2023 14:44:47 GMT
  */
 
 module.exports = {

--- a/lib/sizes/index.d.ts
+++ b/lib/sizes/index.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Jul 2023 21:18:11 GMT
+ * Generated on Mon, 31 Jul 2023 14:44:47 GMT
  */
 
 export default sizes;

--- a/lib/sizes/index.js
+++ b/lib/sizes/index.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Jul 2023 21:18:11 GMT
+ * Generated on Mon, 31 Jul 2023 14:44:47 GMT
  */
 
 module.exports = {

--- a/lib/typography/index.d.ts
+++ b/lib/typography/index.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Jul 2023 21:18:11 GMT
+ * Generated on Mon, 31 Jul 2023 14:44:47 GMT
  */
 
 export const fontFamilyBase: string;

--- a/lib/typography/index.js
+++ b/lib/typography/index.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Jul 2023 21:18:11 GMT
+ * Generated on Mon, 31 Jul 2023 14:44:47 GMT
  */
 
 export const fontFamilyBase = 'Poppins';

--- a/tokens/tokens.json
+++ b/tokens/tokens.json
@@ -485,6 +485,12 @@
   "color": {
     "solid": {
       "faint": {
+        "black": {
+          "category": "color",
+          "exportKey": "color",
+          "value": "rgba(0, 0, 0, 1)",
+          "type": "color"
+        },
         "darkest": {
           "category": "color",
           "exportKey": "color",
@@ -544,6 +550,13 @@
         "lightest": {
           "category": "color",
           "exportKey": "color",
+          "value": "rgba(251, 251, 251, 1)",
+          "type": "color"
+        },
+        "white": {
+          "category": "color",
+          "exportKey": "color",
+          "comment": "background",
           "value": "rgba(255, 255, 255, 1)",
           "type": "color"
         }


### PR DESCRIPTION
# What

- create solid-faint-black and solid-bright-white tokens
- update solid-bright-lightest token

# Why

The UX/UI team has a need to have a color tone that is somewhere between pure white and the `solidBrightLighter` color. Currently this color is too dark for some situations.

Also the `SolidBrightLightest` color is currently used for pure white, however in the other tokens it is not used that way.

# How

Update tokens file and regenerate tokens

<!-- ✅ TODOs -->
<!-- Assign at least one manteiner to review this PR -->
<!-- Assign everyone who worked on this PR -->

<!-- EXTRAS -->
<!-- 💸 Describe possible tech debits -->
<!-- Jira link if needed -->

CONFIA-1309
